### PR TITLE
Update package to 19.15.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "17.17.0" %}
+{% set version = "19.15.0" %}
 
 package:
   name: python-kubernetes
@@ -6,33 +6,30 @@ package:
 
 source:
   url: https://pypi.io/packages/source/k/kubernetes/kubernetes-{{ version }}.tar.gz
-  sha256: c69b318696ba797dcf63eb928a8d4370c52319f4140023c502d7dfdf2080eb79
+  sha256: 08c93f300a9837104282ecc81458b903a56444c5c1ec3d990d237557312af47f
 
 build:
   number: 0
-  noarch: python
   script: {{ PYTHON }} -m pip install . -vv
+  skip: True  # [py<37]
 
 requirements:
   host:
-    - python >=3.6
+    - python
     - pip
     - wheel
-    - setuptools
+    - setuptools >=21.0.0
   run:
-    - python >=3.6
+    - python
     - certifi >=14.05.14
     - google-auth >=1.0.1
     - python-dateutil >=2.5.3
-    - pyyaml >=3.12
+    - pyyaml >=5.4.1
     - requests
     - requests-oauthlib
-    - setuptools >=21.0.0
     - six >=1.9.0
     - urllib3 >=1.24.2
     - websocket-client >=0.32.0,!=0.40.0,!=0.41.*,!=0.42.*
-    # - aiohttp >=3.6.3
-    # - adal >=1.0.2
 
 test:
   requires:
@@ -51,10 +48,13 @@ about:
   home: https://github.com/kubernetes-incubator/client-python
   license: Apache-2.0
   summary: The official Kubernetes python client.
+  description: Python client for kubernetes http://kubernetes.io/
   license_family: APACHE
   license_file: LICENSE
+  license_url: https://www.apache.org/licenses/LICENSE-2.0
   dev_url: https://github.com/kubernetes-incubator/client-python
   doc_url: https://github.com/kubernetes-client/python/blob/master/README.md
+  doc_source_url: https://github.com/kubernetes-client/python/tree/master/doc
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -39,20 +39,22 @@ test:
   imports:
     - kubernetes
     - kubernetes.client
+    - kubernetes.client.api
     - kubernetes.client.apis
     - kubernetes.client.models
     - kubernetes.config
     - kubernetes.watch
+    - kubernetes.utils
 
 about:
-  home: https://github.com/kubernetes-incubator/client-python
+  home: https://github.com/kubernetes-client/python
   license: Apache-2.0
   summary: The official Kubernetes python client.
   description: Python client for kubernetes http://kubernetes.io/
   license_family: APACHE
   license_file: LICENSE
   license_url: https://www.apache.org/licenses/LICENSE-2.0
-  dev_url: https://github.com/kubernetes-incubator/client-python
+  dev_url: https://github.com/kubernetes-client/python
   doc_url: https://github.com/kubernetes-client/python/blob/master/README.md
   doc_source_url: https://github.com/kubernetes-client/python/tree/master/doc
 


### PR DESCRIPTION
This previous version needs to be built out for AE5. Versions 18.20.0, 20.13.0, 21.7.0 are also to be built out but I will raise PRs for these after this one is reviewed (because they are identical apart from version/hash).

Info about changes:
- The pinning of pyyaml is updated to the one used in more recent versions upstream. It is not required for this version upstream. However, the reason for update was to fix a CVE, rather than an API break. So I thought it sensible to use the version with the fixed CVE.
- changes have been made to satisfy the linter
- setuptools is not used at runtime upstream
- noarch is removed as per usual


[Jira issue](https://anaconda.atlassian.net/browse/PKG-116?atlOrigin=eyJpIjoiYTBmYTY4OWIyZDQ2NDljNzk5Yjg4ZDkxODNlNDI0NjYiLCJwIjoiaiJ9)
[Upstream repo](https://github.com/kubernetes-client/python)
[Changelog](https://github.com/kubernetes-client/python/blob/master/CHANGELOG.md)
