### PR TITLE
Update package to 21.7.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 build:
   number: 0
   script: {{ PYTHON }} -m pip install . -vv
-  skip: True  # [py<37]
+  skip: True  # [py<36]
 
 requirements:
   host:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "17.17.0" %}
+{% set version = "21.7.0" %}
 
 package:
   name: python-kubernetes
@@ -6,33 +6,30 @@ package:
 
 source:
   url: https://pypi.io/packages/source/k/kubernetes/kubernetes-{{ version }}.tar.gz
-  sha256: c69b318696ba797dcf63eb928a8d4370c52319f4140023c502d7dfdf2080eb79
+  sha256: c9849afc2eafdce60efa210049ee7a94e7ef6cf3a7afa14a69b3bf0447825977
 
 build:
   number: 0
-  noarch: python
   script: {{ PYTHON }} -m pip install . -vv
+  skip: True  # [py<37]
 
 requirements:
   host:
-    - python >=3.6
+    - python
     - pip
     - wheel
-    - setuptools
+    - setuptools >=21.0.0
   run:
-    - python >=3.6
+    - python
     - certifi >=14.05.14
     - google-auth >=1.0.1
     - python-dateutil >=2.5.3
-    - pyyaml >=3.12
+    - pyyaml >=5.4.1
     - requests
     - requests-oauthlib
-    - setuptools >=21.0.0
     - six >=1.9.0
     - urllib3 >=1.24.2
     - websocket-client >=0.32.0,!=0.40.0,!=0.41.*,!=0.42.*
-    # - aiohttp >=3.6.3
-    # - adal >=1.0.2
 
 test:
   requires:
@@ -42,19 +39,24 @@ test:
   imports:
     - kubernetes
     - kubernetes.client
+    - kubernetes.client.api
     - kubernetes.client.apis
     - kubernetes.client.models
     - kubernetes.config
     - kubernetes.watch
+    - kubernetes.utils
 
 about:
-  home: https://github.com/kubernetes-incubator/client-python
+  home: https://github.com/kubernetes-client/python
   license: Apache-2.0
   summary: The official Kubernetes python client.
+  description: Python client for kubernetes http://kubernetes.io/
   license_family: APACHE
   license_file: LICENSE
-  dev_url: https://github.com/kubernetes-incubator/client-python
+  license_url: https://www.apache.org/licenses/LICENSE-2.0
+  dev_url: https://github.com/kubernetes-client/python
   doc_url: https://github.com/kubernetes-client/python/blob/master/README.md
+  doc_source_url: https://github.com/kubernetes-client/python/tree/master/doc
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
Please see [previously merged v19.15](https://github.com/AnacondaRecipes/python-kubernetes-feedstock/pull/3) for rationale of changes.

This update is exactly the same as that one (apart from the version and sha256), because:

- The only requirement update upstream between v17.17 and the most recent version is pyyaml, see [here](https://github.com/kubernetes-client/python/blame/master/requirements.txt). This is updated in this PR for the same reason as it was updated in the v19.15 PR.
- The API endpoints in the added import checks have also been in since v17.17, see [here](https://github.com/kubernetes-client/python/blob/release-17.0/setup.py)