### PR TITLE
Python 3.12 rebuild of 21.7

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: c9849afc2eafdce60efa210049ee7a94e7ef6cf3a7afa14a69b3bf0447825977
 
 build:
-  number: 1
+  number: 2
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   skip: True  # [py<36]
 


### PR DESCRIPTION
python-kubernetes 21.7

**Destination channel:** defaults

### Explanation of changes:

- rebuild to pick up python 3.12
