### PR TITLE
python-kubernetes 35.0.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "kubernetes" %}
-{% set version = "34.1.0" %}
+{% set version = "35.0.0" %}
 
 package:
   name: python-{{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 8fe8edb0b5d290a2f3ac06596b23f87c658977d46b5f8df9d0f4ea83d0003912
+  sha256: 3d00d344944239821458b9efd484d6df9f011da367ecb155dadf9513f05f09ee
 
 build:
   number: 0
@@ -31,8 +31,7 @@ requirements:
     - websocket-client >=0.32.0,!=0.40.0,!=0.41.*,!=0.42.*
     - requests
     - requests-oauthlib
-    - oauthlib >=3.2.2
-    - urllib3 >=1.24.2,<2.4.0
+    - urllib3 >=1.24.2,!=2.6.0
     - durationpy >=0.7
   run_constrained:
     - adal >=1.0.2


### PR DESCRIPTION
python-kubernetes 35.0.0

**Destination channel:** defaults

### Links

- [PKG-14565](https://anaconda.atlassian.net/browse/PKG-14565) (parent epic [PKG-8303](https://anaconda.atlassian.net/browse/PKG-8303), blocks PKG-7382 chromadb)
- [Upstream repository](https://github.com/kubernetes-client/python)
- [Upstream changelog/diff](https://github.com/kubernetes-client/python/compare/v34.1.0...v35.0.0)
- Conda-forge recipe: https://github.com/conda-forge/python-kubernetes-feedstock/blob/main/recipe/meta.yaml

### Explanation of changes:

- **Version bump 34.1.0 → 35.0.0** (latest upstream). Original ticket scope was just a py3.14 rebuild of 34.1.0, but a rebuild was insufficient: 34.1.0's `urllib3 >=1.24.2,<2.4.0` upper bound excluded the urllib3 2.6.x builds that have py3.14 wheels on pkgs/main, so the new `py314_1` package failed install-time resolution. Upstream 35.0.0 fixed this in its metadata.
- **Recipe changes:**
  - Update sha256 for the 35.0.0 sdist.
  - Reset `build_number` to 0 (new version).
  - **Relax `urllib3` to `>=1.24.2,!=2.6.0`** per [upstream 35.0.0 install_requires](https://pypi.org/pypi/kubernetes/35.0.0/json) — only excludes the buggy 2.6.0 release, no upper bound. Lets the package install on py3.14 against urllib3 2.6.1 / 2.6.3.
  - **Drop `oauthlib`** from run deps — upstream 35.0.0 removed it from `install_requires` (it's still pulled in transitively via `requests-oauthlib`).
- **Coverage:** existing `skip: true  # [py<36]` is unchanged; CI builds across the AnacondaRecipes Python matrix (py3.10–py3.14) including the previously-missing py3.14.

[PKG-14565]: https://anaconda.atlassian.net/browse/PKG-14565?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PKG-8303]: https://anaconda.atlassian.net/browse/PKG-8303?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ