### PR TITLE
bump to 36.0.2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -65,3 +65,5 @@ extra:
   recipe-maintainers:
     - johanneskoester
     - ocefpaf
+  skip-lints:
+    - python_build_tools_in_host

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "kubernetes" %}
-{% set version = "36.0.1" %}
+{% set version = "36.0.2" %}
 
 package:
   name: python-{{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 3eadd6ae1be3b742ae63bd382b139c9fd5171afb6e00771dcefaae2d49001992
+  sha256: 03551fcb49cae1f708f63624041e37403545b7aaed10cbf54e2b01a37a5438e3
 
 build:
   number: 0


### PR DESCRIPTION
python-kubernetes 36.0.2

**Destination channel:** defaults

### Links

- [PKG-15163](https://anaconda.atlassian.net/browse/PKG-15163) 
- [Upstream repository](https://github.com/kubernetes-client/python)
- [Upstream changelog/diff](https://github.com/kubernetes-client/python/blob/release-36.0/CHANGELOG.md)

### Explanation of changes:

Includes this important fix: https://github.com/kubernetes-client/python/pull/2604


[PKG-15163]: https://anaconda.atlassian.net/browse/PKG-15163?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ